### PR TITLE
Update package.json

### DIFF
--- a/complete-vuejs-getting-started/package.json
+++ b/complete-vuejs-getting-started/package.json
@@ -4,18 +4,16 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@vue/compiler-sfc": "^3.0.7",
-    "node": "^12.18.3",
+    "@vue/compiler-sfc": "3.0.7",
     "vue": "3.0.7",
     "vue-router": "4.0.5",
-    "vuex": "4.0.0",
-    "yarn": "^1.22.10"
+    "vuex": "4.0.0"  
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "1.1.5",
     "vite": "2.1.1"
   },
   "peerDependencies": {
-    "@vue/compiler-sfc": "^3.0.7"
+    "@vue/compiler-sfc": "3.0.7"
   }
 }


### PR DESCRIPTION
I got an error installing your project at first. I removed the `node` dependency from `package.json` - now I can run `yarn install`.

I found the issue. [Here's the solution and explanation](https://github.com/vitejs/vite/issues/4573). It looks like when you install a specific version, eg `yarn add vue@3.0.7`,  it adds `^3.0.7` to your `package.json`. The issue is the `@vue/compiler-sfc` must *exactly* match the `vue` version.

You may need to delete `yarn.lock` and re-run `yarn` to get the the matching versions installed.